### PR TITLE
Fixed Backbone 1.1 Breaking Change

### DIFF
--- a/src/leaf.js
+++ b/src/leaf.js
@@ -17,7 +17,8 @@ PrettyJSON.view.Leaf = Backbone.View.extend({
         "mouseover .leaf-container": "mouseover",
         "mouseout .leaf-container": "mouseout"
     },
-    initialize: function(){
+    initialize: function(opts){
+        this.options = opts;
         this.data = this.options.data;
         this.level = this.options.level;
         this.path = this.options.path;

--- a/src/node.js
+++ b/src/node.js
@@ -20,8 +20,8 @@ PrettyJSON.view.Node = Backbone.View.extend({
         'mouseover .node-container': 'mouseover',
         'mouseout .node-container': 'mouseout'
     },
-    initialize:function(){
-
+    initialize:function(opts){
+        this.options = opts;
         this.data = this.options.data;
         this.level = this.options.level || this.level;
         this.path = this.options.path;


### PR DESCRIPTION
See: https://github.com/jashkenas/backbone/issues/2458

Backbone 1.1 No longer stores the options hash passed in to the initialize call of the view.
This PR restores that behavior by storing those options. 
#### Issue:

Undefined options hash when using anything newer then Backbone 1.0. Breaks in Backbone 1.1
See: http://backbonejs.org/#upgrading

```
In 1.1, Backbone Views no longer have the options argument attached as this.options automatically. Feel free to continue attaching it if you like.
```
#### Expected:

Options hash is defined.
